### PR TITLE
Remove the link to pre-requesites

### DIFF
--- a/docs/_includes/01-assignment-1-lab/2-lab-instructions.md
+++ b/docs/_includes/01-assignment-1-lab/2-lab-instructions.md
@@ -31,7 +31,7 @@ This command will read the docker-compose.yml file located within the root folde
    ```bash
    mvn spring-boot:run
    ```
-> If you receive an error here, please double-check whether or not you have installed all the [prerequisites]({{ site.baseurl }}{% link {{include.linkToPrerequisites}} %}) for the workshop!
+> If you receive an error here, please double-check whether or not you have installed all the `prerequisites` for the workshop!
 
 ## Step 3. Run the FineCollection service
 

--- a/docs/modules/01-assignment-1-lab/2-lab-instructions.md
+++ b/docs/modules/01-assignment-1-lab/2-lab-instructions.md
@@ -20,7 +20,7 @@ has_toc: true
 {:toc}
 </details>
 
-{% include 01-assignment-1-lab/2-lab-instructions.md linkToPrerequisites="modules/00-intro/2-prerequisites.md" %}
+{% include 01-assignment-1-lab/2-lab-instructions.md %}
 
 <!-- ----------------------------- NAVIGATION ------------------------------ -->
 

--- a/docs/modules/11-aca-challenge/01-assignment-1-lab/2-lab-instructions.md
+++ b/docs/modules/11-aca-challenge/01-assignment-1-lab/2-lab-instructions.md
@@ -21,7 +21,7 @@ has_toc: true
 {:toc}
 </details>
 
-{% include 01-assignment-1-lab/2-lab-instructions.md linkToPrerequisites="modules/11-aca-challenge/00-intro/2-prerequisites.md" %}
+{% include 01-assignment-1-lab/2-lab-instructions.md %}
 
 <!-- ----------------------------- NAVIGATION ------------------------------ -->
 


### PR DESCRIPTION
Remove the link to pre-requesites because the GitHub version of Jekyll does not support passing link as parameter